### PR TITLE
War-#4: Disabled button on empty deck

### DIFF
--- a/index.css
+++ b/index.css
@@ -55,6 +55,10 @@ h2 {
   background: rgb(236, 208, 45);
 }
 
+.draw-cards:disabled {
+  cursor: not-allowed;
+}
+
 .card-slot {
   margin: 0 auto;
   border: 1px solid #222;

--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@
 let deckId;
 const baseUrl = 'https://apis.scrimba.com/deckofcards/api/deck/';
 const cardSlots = document.getElementById('cards');
+const drawButton = document.getElementById('draw-cards');
 
 const handleClick = () => {
   fetch(`${baseUrl}/new/shuffle/`)
@@ -52,8 +53,9 @@ const determineWinner = (firstCard, secondCard) => {
 };
 
 const remainingCards = (data) => {
+  data.remaining <= 0 ? (drawButton.disabled = true) : (drawButton.disabled = false);
   document.getElementById('cards-remaining').textContent = `Cards Remaining: ${data.remaining}`;
 };
 
+drawButton.addEventListener('click', drawCards);
 document.getElementById('new-deck').addEventListener('click', handleClick);
-document.getElementById('draw-cards').addEventListener('click', drawCards);


### PR DESCRIPTION
Disabled button when remaining cards hit 0 and deck has run out of cards. Styled button to show not-allowed cursor on hover once disabled.